### PR TITLE
docs: add link to known limitations in the faq file

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -12,7 +12,7 @@ The Co-dfns compiler is designed to enable you as an APL programmer to use Dyalo
 
 **Will Co-dfns compile my code?**
 
-That depends. Please check out the limitations file for information about what Co-dfns does not support right now. If you have some code that Co-dfns cannot currently compile, that you'd really like it to compile, talk to me and let's see if we can't make that happen. 
+That depends. Please check out the [limitations](https://github.com/Co-dfns/Co-dfns/blob/master/docs/MANUAL.md#known-limitations) file for information about what Co-dfns does not support right now. If you have some code that Co-dfns cannot currently compile, that you'd really like it to compile, talk to me and let's see if we can't make that happen. 
 
 Keep in mind that some code that people write will simply not perform well on a GPU, even if the compiler did compile that code.
 


### PR DESCRIPTION
I was reading the `docs/FAQ.md` file and had to search through the docs to check for the `limitations file` mentioned since there is no file named limitations. Here:

https://github.com/Co-dfns/Co-dfns/blob/461addba5896b4aba251071691605552195d981e/docs/FAQ.md?plain=1#L15

So I added the URL to the known limitations section of the `docs/MANUAL.md` file to the FAQ answer.

If there is some other page you were referring to, please let me know. I will reference that.