### PR TITLE
Fix parsing of ∘. as the first item in a group.

### DIFF
--- a/cmp/PS.apl
+++ b/cmp/PS.apl
@@ -468,8 +468,7 @@ PS←{⍺←⊢
 	_←{
 		zb←(⌽≠⌽p[zb])⌿zb←zi⌿⍨(zp∊z)∧(k[zi]≠1)∨(≠zp)∧k[zi]=1
 		nk←k[za]×(k[za]≠0)∧za=zc
-                nk+←2×(nk=0)∧(t[za]=P)∧n[za]=-sym⍳⊂,'∘.'
-		nk+←3×(nk=0)∧k[za]∊3 4
+		nk+←3×(nk=0)∧(k[za]∊3 4)∧n[za]≠-sym⍳⊂,'∘.'
 		nk+←(|k[zc])×(nk=0)∧(k[zc]∊¯3 ¯4)∨(t[zb]=P)∧n[zb]=-sym⍳⊂,'.'
 		nk+←2×(nk=0)∧(k[zc]∊2 3 5)∨4=|k[zb]
 		nk+←(nk=0)∧((t[zc]=A)∨1=|k[zc])∧(t[zb]=V)⍲k[zb]=0

--- a/cmp/PS.apl
+++ b/cmp/PS.apl
@@ -468,6 +468,7 @@ PS←{⍺←⊢
 	_←{
 		zb←(⌽≠⌽p[zb])⌿zb←zi⌿⍨(zp∊z)∧(k[zi]≠1)∨(≠zp)∧k[zi]=1
 		nk←k[za]×(k[za]≠0)∧za=zc
+                nk+←2×(nk=0)∧(t[za]=P)∧n[za]=-sym⍳⊂,'∘.'
 		nk+←3×(nk=0)∧k[za]∊3 4
 		nk+←(|k[zc])×(nk=0)∧(k[zc]∊¯3 ¯4)∨(t[zb]=P)∧n[zb]=-sym⍳⊂,'.'
 		nk+←2×(nk=0)∧(k[zc]∊2 3 5)∨4=|k[zb]


### PR DESCRIPTION
∘. is a special form, unlike any other primitive or user defined function (be it a dop or tradop) it is a monadic operator that only accepts one operand on the _right_.  Monadic operators normally accept their operands only on the _left_ so that under the assumption that all monadic operators behave in this way, the next line propagates the kind of the first child of a group to the parent if the first child has kind 3 (i.e. is a monadic operator). This is correct assuming the entire group is well-typed; however ∘. breaks this assumption so we have to handle it seperately.