### PR TITLE
Fix duplicate positions in INVALID CHARACTER errors

### DIFF
--- a/cmp/PS.apl
+++ b/cmp/PS.apl
@@ -51,7 +51,7 @@ PS←{⍺←⊢
 	t pos end⌿⍨←⊂(t≠0)∨(~IN[pos]∊WS)∨⊃¯1 1∧.⌽⊂IN[pos]∊alp,num,'¯⍺⍵⎕.:'
 
 	⍝ Verify all open characters are valid
-	msk←~IN[pos]∊alp,num,syna,synb,prms,WS
+	msk←(t=0)∧~IN[pos]∊alp,num,syna,synb,prms,WS
 	∨⌿msk:'INVALID CHARACTER(S) IN SOURCE'SIGNAL msk⌿pos
 
 	⍝ This simplifies the following expressions


### PR DESCRIPTION
Dummy statement separator tokens (Z) borrow the source position of the first surviving character on each line. If that character is invalid, the previous validation mask flagged both the unprocessed source entry and the synthetic Z entry for that position. This produced duplicate positions in the reported error (or repeated 0s for empty lines).

Restrict the validation mask to unprocessed tokens (t=0), preventing these structural Z tokens from contributing duplicate matches.

Impact: This does not change which source code is accepted or rejected. It strictly improves diagnostics by ensuring each invalid source position is reported exactly once.